### PR TITLE
added getStaticProps to a page to have a SSG example

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -16,13 +16,21 @@ class MyDocument extends Document {
   ): Promise<DocumentInitialProps> {
     const initialProps = await Document.getInitialProps(ctx);
 
-    await new Promise((resolve) => {
-      newrelic.agent.on('connected', resolve)
-    })
+    /**
+     * For SSG pages the build is faster than the agent connect cycle
+     * In those cases, let's wait for the agent to connect before getting
+     * the browser agent script.
+     */
+    if (!newrelic.agent.collector.isConnected()) {
+      await new Promise((resolve) => {
+        newrelic.agent.on('connected', resolve)
+      })
+    }
 
     const browserTimingHeader = newrelic.getBrowserTimingHeader({
       hasToRemoveScriptWrapper: true,
     });
+
 
     logger.info("NextJs New Relic redirecting to a page", {
       application: "NextJs NewRelic app logging",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -16,6 +16,10 @@ class MyDocument extends Document {
   ): Promise<DocumentInitialProps> {
     const initialProps = await Document.getInitialProps(ctx);
 
+    await new Promise((resolve) => {
+      newrelic.agent.on('connected', resolve)
+    })
+
     const browserTimingHeader = newrelic.getBrowserTimingHeader({
       hasToRemoveScriptWrapper: true,
     });

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -29,6 +29,7 @@ class MyDocument extends Document {
 
     const browserTimingHeader = newrelic.getBrowserTimingHeader({
       hasToRemoveScriptWrapper: true,
+      allowTransactionlessInjection: true
     });
 
 

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import Layout from "../components/Layout";
 import * as http from 'http';
 
-function Blog({ posts, test }) {
+function Blog({ posts }) {
   return (
     <Layout>
       <p>
@@ -11,7 +11,6 @@ function Blog({ posts, test }) {
           <a>Home</a>
         </Link>
       </p>
-      <div>{test}</div>
       <ul>
         {posts.map((post) => (
           <li key={post.id}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,30 +1,41 @@
-import type { NextPage } from "next";
 import Link from "next/link";
 
 import Layout from "../components/Layout";
+const LINKS = [
+  {
+    name: "Home",
+    href: "/"
+  },
+  {
+    name: "Blog",
+    href: "/blog"
+  },
+  {
+    name: "About",
+    href: "/about"
+  }
+];
 
-const Home: NextPage = () => {
+function Home({ links }) { 
   return (
     <Layout>
-      <p>
-        <Link href="/">
-          <a>Home</a>
-        </Link>
-      </p>
-
-      <p>
-        <Link href="/blog">
-          <a>Blog</a>
-        </Link>
-      </p>
-
-      <p>
-        <Link href="/about">
-          <a>About</a>
-        </Link>
-      </p>
+      {links.map((link) => (
+        <p key={link.name}>
+          <Link href={link.href}>
+            <a>{link.name}</a>
+          </Link>
+        </p>
+      ))}
     </Layout>
   );
+};
+
+export async function getStaticProps() {
+  return { 
+    props: {
+      links: LINKS
+    }
+  }
 };
 
 export default Home;


### PR DESCRIPTION
This PR adds a getStaticProps method to the index page to show an example of a SSG page.  This also adds more logic to pages/_document.tsx to wait for agent to be connected before getting the browser timing header.  This was discovered as an issue while testing out a fix to `getBrowserTimingHeader` that supports running when not in a transaction context.  See PR [here](https://github.com/newrelic/node-newrelic/pull/1475)