### PR TITLE
(feat) add typescript types to New Relic related components

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
+        "@types/newrelic": "^9.4.0",
         "@types/react": "17.0.30",
         "babel-preset-env": "^1.7.0",
         "eslint": "7.32.0",
@@ -822,6 +823,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "dev": true
+    },
+    "node_modules/@types/newrelic": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@types/newrelic/-/newrelic-9.4.0.tgz",
+      "integrity": "sha512-09jlh+c8zBwbYegstS74IDfWliDf72Bwf4gNyRQ81u29Xm/vIKfzkGfAywVLfMjE6nsii4WRNu7raRAyNSLNVQ==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -6255,6 +6262,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "dev": true
+    },
+    "@types/newrelic": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@types/newrelic/-/newrelic-9.4.0.tgz",
+      "integrity": "sha512-09jlh+c8zBwbYegstS74IDfWliDf72Bwf4gNyRQ81u29Xm/vIKfzkGfAywVLfMjE6nsii4WRNu7raRAyNSLNVQ==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
+    "@types/newrelic": "^9.4.0",
     "@types/react": "17.0.30",
     "babel-preset-env": "^1.7.0",
     "eslint": "7.32.0",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -12,7 +12,7 @@ import { logger } from "../components/Logger";
 
 type NewRelicProps = {
   browserTimingHeader: string;
-}
+};
 
 class MyDocument extends Document<NewRelicProps> {
   static async getInitialProps(
@@ -27,15 +27,14 @@ class MyDocument extends Document<NewRelicProps> {
      */
     if (!newrelic.agent.collector.isConnected()) {
       await new Promise((resolve) => {
-        newrelic.agent.on('connected', resolve)
-      })
+        newrelic.agent.on("connected", resolve);
+      });
     }
 
     const browserTimingHeader = newrelic.getBrowserTimingHeader({
       hasToRemoveScriptWrapper: true,
-      allowTransactionlessInjection: true
+      allowTransactionlessInjection: true,
     });
-
 
     logger.info("NextJs New Relic redirecting to a page", {
       application: "NextJs NewRelic app logging",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -10,10 +10,14 @@ import Document, {
 
 import { logger } from "../components/Logger";
 
-class MyDocument extends Document {
+type NewRelicProps = {
+  browserTimingHeader: string;
+}
+
+class MyDocument extends Document<NewRelicProps> {
   static async getInitialProps(
     ctx: DocumentContext
-  ): Promise<DocumentInitialProps> {
+  ): Promise<DocumentInitialProps & NewRelicProps> {
     const initialProps = await Document.getInitialProps(ctx);
 
     /**
@@ -41,7 +45,6 @@ class MyDocument extends Document {
 
     return {
       ...initialProps,
-      // @ts-ignore
       browserTimingHeader,
     };
   }
@@ -52,7 +55,6 @@ class MyDocument extends Document {
         <Head>
           <script
             type="text/javascript"
-            // @ts-ignore
             dangerouslySetInnerHTML={{ __html: this.props.browserTimingHeader }}
           />
         </Head>

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,4 +1,10 @@
-function Error({ statusCode }) {
+import { NextPage, NextPageContext } from "next";
+
+type Props = {
+  statusCode: number | undefined;
+};
+
+const Error: NextPage<Props> = ({ statusCode }) => {
   return (
     <p>
       {statusCode
@@ -6,14 +12,13 @@ function Error({ statusCode }) {
         : "An error occurred on client"}
     </p>
   );
-}
+};
 
-Error.getInitialProps = ({ res, err }) => {
+Error.getInitialProps = ({ res, err }: NextPageContext) => {
   if (typeof window == "undefined") {
     const newrelic = require("newrelic");
     newrelic.noticeError(err);
   } else {
-    // @ts-ignore
     window.newrelic.noticeError(err);
   }
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,18 @@
+import type newrelic from "newrelic";
+
+interface Newrelic extends newrelic {
+  noticeError(
+    error: (Error & { statusCode?: number | undefined }) | null | undefined
+  ): void;
+  addPageAction: (actionName: string, customAttributes?: object) => void;
+  setCustomAttribute: (key: string, value: string | number) => void;
+  // add more methods here if you need them
+  // https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/using-browser-apis/
+}
+
+// for the New Relic browser agent
+declare global {
+  interface Window {
+    newrelic: Newrelic;
+  }
+}

--- a/types/newrelic.d.ts
+++ b/types/newrelic.d.ts
@@ -1,0 +1,18 @@
+import "@types/newrelic";
+
+// for the New Relic Node.js agent
+interface Collector {
+  isConnected(): boolean;
+}
+
+interface Agent {
+  on(event: string, callback: (arg: any) => void): void;
+  collector: Collector;
+}
+
+declare module "newrelic" {
+  export const agent: Agent;
+  export function noticeError(
+    error: (Error & { statusCode?: number | undefined }) | null | undefined
+  ): void;
+}

--- a/types/newrelic.d.ts
+++ b/types/newrelic.d.ts
@@ -15,4 +15,9 @@ declare module "newrelic" {
   export function noticeError(
     error: (Error & { statusCode?: number | undefined }) | null | undefined
   ): void;
+  export function getBrowserTimingHeader(options?: {
+    nonce?: string;
+    hasToRemoveScriptWrapper?: boolean;
+    allowTransactionlessInjection?: boolean;
+  }): string;
 }


### PR DESCRIPTION
# Changes

* Fixes 2 TypeScript errors in pages/_document.tsx

# Notes

* I tried including `@types/newrelic` but those seem outdated since `newrelic.agent` and the `allowTransactionlessInjection` option on `getBrowserTimingHeader` do not yet exist.