### PR TITLE
(fix) Change New Relic 'require' with 'import'

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,4 +1,4 @@
-const newrelic = require("newrelic");
+import newrelic from "newrelic";
 import Document, {
   DocumentContext,
   DocumentInitialProps,


### PR DESCRIPTION
# Changes

Replaces the New Relic `require` with `import`

# Why

We use `import` everywhere else in the file